### PR TITLE
17337: Add uncertainty to terminology section

### DIFF
--- a/source/user_guide/sparse_data.rst
+++ b/source/user_guide/sparse_data.rst
@@ -71,10 +71,10 @@ to unseen data**.  As such, we recommend performing no preprocessing if possible
 
 What a Missing Value Means
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-When computing similarity between cases, a missing value is considered to be of maximal uncertainty for that feature.  This is true even if both cases 
-have missing values in the same place.  After all, :math:`NaN \neq NaN`.  As mentioned above, if the data you are working with contain missing values 
-that represent something specific, those should be changed from missing values to something else.  If we were to treat those values as missing, matches 
-would not be considered similar and may therefore harm predictions in that instance.
+When computing similarity between cases, a missing value is considered to be of maximal :ref:`uncertainty <user_guide/terminology:uncertainty>` 
+for that feature.  This is true even if both cases have missing values in the same place.  After all, :math:`NaN \neq NaN`.  As mentioned above, 
+if the data you are working with contain missing values that represent something specific, those should be changed from missing values to something 
+else.  If we were to treat those values as missing, matches would not be considered similar and may therefore harm predictions in that instance.
 
 
 How Well are Sparse Data Handled

--- a/source/user_guide/terminology.rst
+++ b/source/user_guide/terminology.rst
@@ -113,6 +113,14 @@ Influential Cases
 
 The cases used to make a prediction or to derive a result.
 
+Uncertainty
+-----------
+
+`Uncertainty <https://en.wikipedia.org/wiki/Measurement_uncertainty>`_ is an expression of the measurement error of 
+a particular feature.  One example of an uncertainty measure is the standard deviation of a distribution.  When Howso 
+Engine computes distances between one or more missing values, they are treated as having maximal uncertainty for 
+the feature.
+
 
 Operations
 ^^^^^^^^^^


### PR DESCRIPTION
- Adds a definition of uncertainty, which links to the Wikipedia article for that definition, to the terminology section of the user-guide
- References this new definition in the Sparse Data user guide