### PR TITLE
17826: Adds documentation for client-configuration

### DIFF
--- a/source/getting_started/client_configuration.rst
+++ b/source/getting_started/client_configuration.rst
@@ -1,0 +1,150 @@
+Client Configuration
+====================
+
+The HowsoEngine's python client (``HowsoDirectClient``) is designed to work well
+without any special configuration. However, there may be circumstances where
+additional options may be useful.
+
+
+How to Create a Configuration File
+----------------------------------
+
+The configuration file is simple a text file with the name ``howso.yml`` and is
+located in one of these places:
+
+1. At any valid file path that is stored in an environment variable: ``HOWSO_CONFIG``,
+2. Within your current working directory,
+3. Within your OS-specific "home" directory inside a directory called ``.howso``,
+
+- On Windows, the "home" directory is stored in the ``%USERPROFILE%`` environment variable.
+- On MacOS or Linux, the "home" directory is the location stored in the ``$USER`` environment variable.
+
+4. Within your configured ``XDG_DIR_CONFIG_PATH`` path (see documentation at `freedesktop.org <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_ for more information).
+
+.. NOTE::
+
+    If there are multiple ``howso.yml`` files, they will be searched for in the above
+    order and the first one found will be used.
+
+
+Structure of the configuration file
+-----------------------------------
+
+The top-level of the file is the ``howso`` section:
+
+- ``howso``
+
+  This is the top-level for Howso Engine options. It has two primary sub-sections:
+  ``client`` and ``client_extra_params``:
+
+  - ``client``
+
+    Specify the client to use by it's dotted Python path. The default value is
+    ``howso.direct.HowsoDirectClient``.
+
+    This is an advanced user option can be used to define and use other clients
+    which subclass ``HowsoDirectClient`` but provide alternate behavior. This may
+    be useful for adding additional authentication, for example.
+
+  - ``client_extra_params``
+
+    This section is for providing options to Amalgam (``amalgam``) and the
+    Howso Engine (``core``):
+
+    - ``amalgam``
+
+      The Howso Engine is built upon `Amalgam <https://github.com/howsoai/amalgam>`_.
+      This section holds options that are specific to the usage of `Amalgam`
+      and/or the Python client: `amalgam-lang`. The options here are as follows:
+
+      - ``library_postfix``
+
+        The Amalgam shared libraries are compiled for different modes of
+        operation. Each of the valid values for this option are:
+
+        - ``-mt`` for Multithreaded operation. This is almost always the best
+          option (and is thus the default on most systems).
+        - ``-st`` for Singlethreaded operation. In rare cases usually involving
+          small Trainee models, this may be the best option.
+        - ``-openmp`` for Multi Processing using the `OpenMP <https://openmp.org>`_ library.
+          This option may be useful when latency is paramount.
+        - ``-pgc`` for "Pedantic Garbage Collection". This is exclusively used
+          by developers in Amalgam debugging scenarios.
+
+      - ``debug``
+
+        - ``false`` (the default)
+        - ``true`` Use this option for additional debugging information in the
+          Amalgam trace files.
+
+      - ``trace``
+
+        - ``false`` (default) - No trace files are written.
+        - ``true`` - Use this option to generate tracefiles.
+
+      - ``execution_trace_dir``
+
+        Set the desired path where tracefiles should be written. The path
+        must be a valid directory with write permission for the
+        operating user. The default value is the current working directory.
+
+        - ``execution_trace_file``
+
+          Set the desired file name for the trace files. Default value is
+          ``<trainee_name>.trace``.
+
+        - ``arch``
+
+          Target CPU architecture of the amalgam library. This is determined
+          programmatically by default and should only be overridden here by
+          advanced users.
+
+          Valid values are:
+
+          - ``x86_64`` - Most Windows, older MacOS, and linux machines
+          - ``arm64`` - Modern MacOS and some Linux machines
+          - ``arm64_8a`` - Specifically compiled for CPUs compatible with
+            generation 1 ``aarch64`` instruction sets such as early Raspberry
+            Pi's and some early Graviton processors.
+
+        - ``os``
+
+          Target operating system of the amalgam library.
+
+          Valid values are:
+
+          - ``linux``
+          - ``darwin``
+          - ``windows``
+
+    - ``core``
+
+      This section is for changing the behavior of the Howso Engine (the Amalgam
+      shared objects).
+
+      - ``persisted_trainees_dir``
+
+        By default, persisted trainees are stored in the current working directory.
+        Set this option to a valid path with sufficient write permissions to
+        store all persisted trainees if so desired.
+
+
+Example Configuration File
+--------------------------
+
+.. NOTE::
+
+    By default, the Howso Engine will automatically choose sensible default
+    values for options making a configuration file entirely optional.
+
+This is an example ``howso.yml`` file which overrides a few options for an
+early model Raspberry Pi ::
+
+    howso:
+        client: howso.direct.HowsoDirectClient
+        client_extra_params:
+            amalgam:
+                arch: arm64_8a
+                library_postfix: -st
+            core:
+            persisted_trainees_dir: /home/jsmith/howso_trainees

--- a/source/getting_started/client_configuration.rst
+++ b/source/getting_started/client_configuration.rst
@@ -57,41 +57,17 @@ The top-level of the file is the ``howso`` section:
       This section holds options that are specific to the usage of `Amalgam`
       and/or the Python client: `amalgam-lang`. The options here are as follows:
 
-      - ``library_postfix``
-
-        The Amalgam shared libraries are compiled for different modes of
-        operation. Each of the valid values for this option are:
-
-        - ``-mt`` for Multithreaded operation. This is almost always the best
-          option (and is thus the default on most systems).
-        - ``-st`` for Singlethreaded operation. In rare cases usually involving
-          small Trainee models, this may be the best option.
-        - ``-openmp`` for Multi Processing using the `OpenMP <https://openmp.org>`_ library.
-          This option may be useful when latency is paramount.
-        - ``-pgc`` for "Pedantic Garbage Collection". This is exclusively used
-          by developers in Amalgam debugging scenarios.
-
       - ``debug``
 
         - ``false`` (the default)
         - ``true`` Use this option for additional debugging information in the
           Amalgam trace files.
 
-      - ``trace``
+      - ``library_path``
 
-        - ``false`` (default) - No trace files are written.
-        - ``true`` - Use this option to generate tracefiles.
-
-      - ``execution_trace_dir``
-
-        Set the desired path where tracefiles should be written. The path
-        must be a valid directory with write permission for the
-        operating user. The default value is the current working directory.
-
-        - ``execution_trace_file``
-
-          Set the desired file name for the trace files. Default value is
-          ``<trainee_name>.trace``.
+        Specify a full path to an Amalgam shared library (DLL, SO, DyLib). This
+        is an advanced setting for developers who compile their own Amalgam
+        shared object binaries.
 
         - ``arch``
 
@@ -107,15 +83,43 @@ The top-level of the file is the ``howso`` section:
             generation 1 ``aarch64`` instruction sets such as early Raspberry
             Pi's and some early Graviton processors.
 
+      - ``execution_trace_dir``
+
+        Set the desired path where tracefiles should be written. The path
+        must be a valid directory with write permission for the
+        operating user. The default value is the current working directory.
+
+      - ``execution_trace_file``
+
+        Set the desired file name for the trace files. Default value is
+        ``<trainee_name>.trace``.
+
+      - ``library_postfix``
+
+        The Amalgam shared libraries are compiled for different modes of
+        operation. Each of the valid values for this option are:
+
+        - ``-mt`` for Multithreaded operation. This is almost always the best
+          option (and is thus the default on most systems).
+        - ``-st`` for Singlethreaded operation. In rare cases usually involving
+          small Trainee models, this may be the best option.
+        - ``-openmp`` for Multi Processing using the `OpenMP <https://openmp.org>`_ library.
+          This option may be useful when latency is paramount.
+        - ``-pgc`` for "Pedantic Garbage Collection". This is exclusively used
+          by developers in Amalgam debugging scenarios.
+
         - ``os``
 
-          Target operating system of the amalgam library.
-
-          Valid values are:
+          Target operating system of the amalgam library. Valid values are:
 
           - ``linux``
           - ``darwin``
           - ``windows``
+
+      - ``trace``
+
+        - ``false`` (default) - No trace files are written.
+        - ``true`` - Use this option to generate tracefiles.
 
     - ``core``
 
@@ -127,6 +131,23 @@ The top-level of the file is the ``howso`` section:
         By default, persisted trainees are stored in the current working directory.
         Set this option to a valid path with sufficient write permissions to
         store all persisted trainees if so desired.
+
+    - ``howso_path``
+
+      Specify a specific location to look for the Howso Engine (core). This is
+      an advanced setting used by developers.
+
+    - ``howso_fname``
+
+      Specify a specific filename for the Howso Engine (core). This is an
+      advanced setting used by developers.
+
+    - ``trainee_template_path``
+
+      Specify the path to look for the howso-template trainee_template_fname -
+      Specify the filename to use for the howso-template. This is an advanced
+      setting used by developers.
+
 
 
 Example Configuration File

--- a/source/getting_started/example_config.yml
+++ b/source/getting_started/example_config.yml
@@ -1,0 +1,8 @@
+howso:
+  client: howso.direct.HowsoDirectClient
+  client_extra_params:
+    amalgam:
+      arch: arm64_8a
+      library_postfix: -st
+    core:
+      persisted_trainees_dir: /home/jsmith/howso_trainees

--- a/source/getting_started/index.rst
+++ b/source/getting_started/index.rst
@@ -3,21 +3,21 @@ Getting Started
 ===============
 To get started, install the Howso Engine
 
-  - :doc:`Installing the Howso Engine <installing>`
+- :doc:`Installing the Howso Engine <installing>`
 
 Learn Howso key concepts and terminology
 
-  - :doc:`Key Concepts <concepts>`
+- :doc:`Key Concepts <concepts>`
 
 Explore basic user guides to perform your first tasks
 
- - :doc:`Basic Workflow <../user_guide/basic_workflow>`
- - :doc:`Feature Attributes <../user_guide/feature_attributes>`
- - :doc:`Regression and Classification<../user_guide/predictions>`
+- :doc:`Basic Workflow <../user_guide/basic_workflow>`
+- :doc:`Feature Attributes <../user_guide/feature_attributes>`
+- :doc:`Regression and Classification<../user_guide/predictions>`
 
 Download and run introductory recipes (sample notebooks)
 
-  - :doc:`Recipes <../examples/index>`
+- :doc:`Recipes <../examples/index>`
 
 .. toctree::
     :maxdepth: 2
@@ -25,6 +25,3 @@ Download and run introductory recipes (sample notebooks)
 
     installing
     concepts
-
-
-

--- a/source/getting_started/installing.rst
+++ b/source/getting_started/installing.rst
@@ -9,6 +9,14 @@ Installing from PyPi
     pip install -U howso-engine
 
 
+Client Configuration
+--------------------
+
+The Howso Engine determines very sensible defaults out-of-the-box making this
+step optional. However, it may be useful to change certain aspects or behaviors
+of operation. See: :doc:`Client Configuration <client_configuration>` for further information.
+
+
 Verification
 ------------
 
@@ -83,3 +91,9 @@ Step 3 - Supplemental File (Microsoft Windows Only):
         ... zishrink.awk
         ... zone.tab
         ... zone1970.tab
+
+.. toctree::
+    :maxdepth: 1
+    :hidden:
+
+    client_configuration


### PR DESCRIPTION
Add documentation about how to create and use a `howso.yml` file for HowsoDirectClient usage.