### PR TITLE
Removing deprecated 'robust calculation' flags in user guide.

### DIFF
--- a/source/user_guide/feature_importance.rst
+++ b/source/user_guide/feature_importance.rst
@@ -85,12 +85,11 @@ metrics may be specified together, but for this example they are separated. If r
 Local Feature Importance
 ^^^^^^^^^^^^^^^^^^^^^^^^
 To get local feature importance metrics, :py:meth:`Trainee.react`, is first called on a trained and analyzed Trainee. In this method, the desired metrics, ``feature_contributions`` and ``feature_mda``, can be selected as inputs to the ``details`` parameters as key value pairs from a dictionary. These parameters are named individually
-and setting them to ``True`` will calculate the desired metrics. To calculate the robust versions, ``robust_computation`` is set to True.
+and setting them to ``True`` will calculate the desired metrics. Robust calculations are performed by default.
 
 .. code-block:: python
 
     details = {
-        'robust_computation':True,
         'feature_contributions':True,
         'feature_mda':True,
     }

--- a/source/user_guide/influential_data_counterfactuals_uncertainty.rst
+++ b/source/user_guide/influential_data_counterfactuals_uncertainty.rst
@@ -75,7 +75,6 @@ We will use the local feature residual to examine the uncertainty for a specific
     ## Compute local feature residuals
     # Details describe the information we are getting from a given react call
     details = {
-        'robust_computation': True,
         'feature_residuals': True,
     }
 

--- a/source/user_guide/understanding_predictions.rst
+++ b/source/user_guide/understanding_predictions.rst
@@ -93,12 +93,11 @@ the power set of all combinations with and without the case of interest. Robust 
 
 
 To get the case importance metrics, :py:meth:`Trainee.react`, is first called on a trained and analyzed Trainee. In this method, the desired metrics, ``case_contributions`` and ``case_mda``, can be selected as inputs to the ``details`` parameters as key value pairs from a dictionary. These parameters are named individually
-and setting them to ``True`` will calculate the desired metrics. To calculate the robust versions, ``robust_computation`` is set to True.
+and setting them to ``True`` will calculate the desired metrics. Robust computation is performed by default.
 
 .. code-block:: python
 
     details = {
-        'robust_computation':True,
         'case_contributions':True,
         'case_mda':True,
     }


### PR DESCRIPTION
Fixed references to robust calculations in the user guides that have been deprecated in the next release. 