### PR TITLE
18897: Add a description of the 'universal' time series attribute

### DIFF
--- a/source/user_guide/time_series.rst
+++ b/source/user_guide/time_series.rst
@@ -62,12 +62,21 @@ Task 1 - Infer Feature Attributes
     # Identify id-feature and time-feature
     id_feature_name = "ID"
     time_feature_name = "date"
-    features = guess_time_series_attributes(
+    features = infer_feature_attributes(
         df,
         time_feature_name=time_feature_name,
         id_feature_name=id_feature_name,
         datetime_feature_formats={"date": "%Y-%m-%d"},
+        time_feature_is_universal=True,
     )
+
+When calling `infer_feature_attributes` in time-series flows, it's imperative that the user specifies the time feature name and the id feature name. While not required, another very significant
+parameter to consider is the `time_feature_is_universal` flag. This is a boolean flag that specifies to the Engine if the time feature should be considered "universal". If the time feature is universal,
+then the Engine is not able to reference any future data when making a prediction. For example, if the Engine is trained on stock data and is to predict the value of a stock on March 8th, then it will not
+be able to reference the value of any stocks on March 9th. If the Engine could look at future data like this, then it may reveal that all stocks dropped in value that day, which would make for an unfair prediction.
+
+If the time feature is not universal, then the Engine could use future data from other series, but still not future data within the same series. It is recommended to set this
+flag to True if there is any possibility of global relevancy of time, which is the default behavior.
 
 Task 2 - Make a time series prediction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/user_guide/time_series.rst
+++ b/source/user_guide/time_series.rst
@@ -71,12 +71,10 @@ Task 1 - Infer Feature Attributes
     )
 
 When calling `infer_feature_attributes` in time-series flows, it's imperative that the user specifies the time feature name and the id feature name. While not required, another very significant
-parameter to consider is the `time_feature_is_universal` flag. This is a boolean flag that specifies to the Engine if the time feature should be considered "universal". If the time feature is universal,
-then the Engine is not able to reference any future data when making a prediction. For example, if the Engine is trained on stock data and is to predict the value of a stock on March 8th, then it will not
-be able to reference the value of any stocks on March 9th. If the Engine could look at future data like this, then it may reveal that all stocks dropped in value that day, which would make for an unfair prediction.
+parameter to consider is the `time_feature_is_universal` flag. This is a boolean flag that specifies to the Engine if the time feature should be considered "universal".
 
-If the time feature is not universal, then the Engine could use future data from other series, but still not future data within the same series. It is recommended to set this
-flag to True if there is any possibility of global relevancy of time, which is the default behavior.
+If the time feature is universal, then the Engine is not able to reference any future data when making a prediction. If the time feature is not universal, then the Engine could use future data
+from other series, but still not future data within the same series. It is recommended to set this flag to True if there is any possibility of global relevancy of time, which is the default behavior.
 
 Task 2 - Make a time series prediction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add a description of the 'universal' feature attribute and what it means. Additionally demonstrate how to use the closely related 'time_feature_is_universal' flag in `infer_feature_attributes`. 