### PR TITLE
22274: Add 'shared_deviations'  to feature attributes page

### DIFF
--- a/source/howso/types/FeatureAttributes.md
+++ b/source/howso/types/FeatureAttributes.md
@@ -165,6 +165,16 @@ Round to the specified significant digits, default is no rounding.
 
 ```
 
+```{py:attribute} shared_deviations
+:type: Optional[list[str]]
+
+A list of feature names that will share deviations with this feature. In analysis, the predictions computed for this feature
+and the features specified are combined to create deviations that are used for all of the included features. If a time series
+feature, then child lag features will automatically share deviations. If 'shared_deviations' is specified as False, then
+automatically created lag features will not automatically share deviations.
+
+```
+
 ```{py:attribute} subtype
 :type: Optional[str]
 


### PR DESCRIPTION
Adds the new "shared_deviations" feature attribute to the docs page for feature attributes